### PR TITLE
Ssuto 34 cancel booking

### DIFF
--- a/src/main/java/com/ss/utopia/tickets/controller/TicketsController.java
+++ b/src/main/java/com/ss/utopia/tickets/controller/TicketsController.java
@@ -87,6 +87,15 @@ public class TicketsController {
     return ResponseEntity.status(HttpStatus.CREATED).body(tickets);
   }
 
+  @PreAuthorize("hasAnyRole('ADMIN','EMPLOYEE','TRAVEL_AGENT')"
+      + " OR @customerAuthenticationManager.customerIdMatches(authentication, #ticketId)")
+  @PutMapping("/cancel/{ticketId}")
+  public ResponseEntity<Ticket> cancelTicket(@PathVariable Long ticketId) {
+    log.info("PUT cancel ticket id=" + ticketId);
+    service.cancelTicket(ticketId);
+    return ResponseEntity.noContent().build();
+  }
+
   @EmployeeOnlyPermission
   @PutMapping("/{id}")
   //Ticket type not strictly necessary since this only returns 204

--- a/src/main/java/com/ss/utopia/tickets/exception/BadStatusUpdateException.java
+++ b/src/main/java/com/ss/utopia/tickets/exception/BadStatusUpdateException.java
@@ -1,0 +1,32 @@
+package com.ss.utopia.tickets.exception;
+
+import com.ss.utopia.tickets.entity.Ticket.TicketStatus;
+
+public class BadStatusUpdateException extends IllegalStateException {
+
+  private final Long ticketId;
+  private final TicketStatus currentStatus;
+  private final TicketStatus requestedStatus;
+
+  public BadStatusUpdateException(Long ticketId,
+                                  TicketStatus currentStatus,
+                                  TicketStatus requestedStatus) {
+    super("Cannot update ticket id=" + ticketId + " to status " + requestedStatus
+            + ", already " + currentStatus);
+    this.ticketId = ticketId;
+    this.currentStatus = currentStatus;
+    this.requestedStatus = requestedStatus;
+  }
+
+  public Long getTicketId() {
+    return ticketId;
+  }
+
+  public TicketStatus getCurrentStatus() {
+    return currentStatus;
+  }
+
+  public TicketStatus getRequestedStatus() {
+    return requestedStatus;
+  }
+}

--- a/src/main/java/com/ss/utopia/tickets/exception/ExceptionControllerAdvisor.java
+++ b/src/main/java/com/ss/utopia/tickets/exception/ExceptionControllerAdvisor.java
@@ -26,4 +26,16 @@ public class ExceptionControllerAdvisor {
 
     return response;
   }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(BadStatusUpdateException.class)
+  public Map<String, Object> badStatusUpdateException(BadStatusUpdateException ex) {
+    LOGGER.error(ex.getMessage());
+    var response = new HashMap<String, Object>();
+
+    response.put("error", ex.getMessage());
+    response.put("status", HttpStatus.BAD_REQUEST);
+
+    return response;
+  }
 }

--- a/src/main/java/com/ss/utopia/tickets/service/TicketService.java
+++ b/src/main/java/com/ss/utopia/tickets/service/TicketService.java
@@ -18,4 +18,6 @@ public interface TicketService {
   List<Ticket> purchaseTickets(PurchaseTicketDto purchaseTicketDto);
 
   void checkIn(Long ticketId);
+
+  void cancelTicket(Long ticketId);
 }

--- a/src/main/java/com/ss/utopia/tickets/service/TicketsServiceImpl.java
+++ b/src/main/java/com/ss/utopia/tickets/service/TicketsServiceImpl.java
@@ -3,6 +3,7 @@ package com.ss.utopia.tickets.service;
 import com.ss.utopia.tickets.dto.PurchaseTicketDto;
 import com.ss.utopia.tickets.entity.Ticket;
 import com.ss.utopia.tickets.entity.Ticket.TicketStatus;
+import com.ss.utopia.tickets.exception.BadStatusUpdateException;
 import com.ss.utopia.tickets.exception.NoSuchTicketException;
 import com.ss.utopia.tickets.repository.TicketsRepository;
 import java.time.ZonedDateTime;
@@ -51,6 +52,18 @@ public class TicketsServiceImpl implements TicketService {
         .stream()
         .map(repository::save)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public void cancelTicket(Long ticketId) {
+    var ticket = getTicketById(ticketId);
+    var status = ticket.getStatus();
+    if (status == TicketStatus.CANCELLED) {
+      throw new BadStatusUpdateException(ticketId, status, TicketStatus.CANCELLED);
+    }
+    ticket.setStatus(TicketStatus.CANCELLED);
+    //for future payment integration: fire off a refund request to the processor here
+    repository.save(ticket);
   }
 
   @Override

--- a/src/test/java/com/ss/utopia/tickets/controller/TicketsControllerSecurityTests.java
+++ b/src/test/java/com/ss/utopia/tickets/controller/TicketsControllerSecurityTests.java
@@ -319,6 +319,37 @@ public class TicketsControllerSecurityTests {
             .andExpect(status().isForbidden());
   }
 
+  @Test
+  void test_cancelTicket_CanOnlyBePerformedByAuthedUsersOrPurchaser() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+            MockUser.TRAVEL_AGENT,
+            MockUser.EMPLOYEE,
+            MockUser.MATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      mvc
+              .perform(
+                      put(EndpointConstants.API_V_0_1_TICKETS + "/cancel/"
+                              + mockTicket.getId())
+                              .header("Authorization", getJwt(user)))
+              .andExpect(status().isNoContent());
+    }
+    var unauthed = List.of(MockUser.DEFAULT,
+            MockUser.UNMATCH_CUSTOMER);
+    for (var user : unauthed) {
+      mvc
+              .perform(
+                      put(EndpointConstants.API_V_0_1_TICKETS + "/cancel/"
+                              + mockTicket.getId())
+                              .header("Authorization", getJwt(user)))
+              .andExpect(status().isForbidden());
+    }
+    mvc
+            .perform(
+                    get(EndpointConstants.API_V_0_1_TICKETS + "/cancel/"
+                            + mockTicket.getId()))
+            .andExpect(status().isForbidden());
+  }
+
   enum MockUser {
     DEFAULT("default@test.com", "ROLE_DEFAULT", UUID.randomUUID().toString()),
     MATCH_CUSTOMER("eddy_grant@test.com", "ROLE_CUSTOMER", "a4a9feca-bfe7-4c45-8319-7cb6cdd359db"),


### PR DESCRIPTION
Adds /cancel/ticketId endpoint to cancel a ticket, as well as a new exception for when the ticket is already cancelled, and controller and unit tests for them.